### PR TITLE
Add description and repository fields to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 license = "MIT"
 authors = ["Microsoft"]
 repository = "https://github.com/microsoft/stackfuture"
+keywords = ["async", "no_std", "futures"]
+categories = ["asynchronous"]
 
 [dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,12 @@
 
 [package]
 name = "stackfuture"
+description = "StackFuture is a wrapper around futures that stores the wrapped future in space provided by the caller."
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Microsoft"]
+repository = "https://github.com/microsoft/stackfuture"
 
 [dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 authors = ["Microsoft"]
 repository = "https://github.com/microsoft/stackfuture"
 keywords = ["async", "no_std", "futures"]
-categories = ["asynchronous"]
+categories = ["asynchronous", "no-std", "rust-patterns"]
 
 [dependencies]
 


### PR DESCRIPTION
I'm getting ready to push our first release to crates.io and it'd be better if we had these fields set first.