### PR TITLE
ci: Add check and clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,15 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
+    - name: Format
+      run: cargo fmt --all -- --check
+    - name: Check
+      run: cargo check --all-features --all-targets
+    - name: Clippy
+      run: cargo clippy --all-features --all-targets -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+reorder_imports = true


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR adds fmt, check and clippy for CI. I also added `rust-toolchain.toml` and `rustfmt.toml` to make our contributors' lives easier.

Fix #4 