### PR TITLE
Bump to version 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "stackfuture"
 description = "StackFuture is a wrapper around futures that stores the wrapped future in space provided by the caller."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Microsoft"]


### PR DESCRIPTION
Since we had a stacked borrows violation report (#9), I'd like to get a patch version of this crate published quickly.