### PR TITLE
Add try_from constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,8 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
     ///
     /// See the documentation on [`StackFuture`] for examples of how to use this.
     ///
+    /// # Panics
+    ///
     /// Panics if the requested `StackFuture` is not large enough to hold `future` or we cannot
     /// satisfy the alignment requirements for `F`.
     pub fn from<F>(future: F) -> Self
@@ -148,6 +150,8 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
     ///
     /// If the `StackFuture` is not large enough to hold `future`, this function returns an
     /// `Err` with the argument `future` returned to you.
+    ///
+    /// Panics
     ///
     /// If we cannot satisfy the alignment requirements for `F`, this function will panic.
     pub fn try_from<F>(future: F) -> Result<Self, F>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -132,3 +132,13 @@ fn send_one_two_three(mut tx: mpsc::Sender<i32>) -> StackFuture<'static, (), 512
         }
     })
 }
+
+#[test]
+fn try_from() {
+    let big_future = StackFuture::<_, 1000>::from(async {});
+
+    match StackFuture::<_, 10>::try_from(big_future) {
+        Ok(_) => panic!("try_from should not have succeeded"),
+        Err(big_future) => assert!(StackFuture::<_, 1500>::try_from(big_future).is_ok()),
+    };
+}


### PR DESCRIPTION
This gives a version that does not panic if the future does not fit which allows programs to recover, such as by boxing the future instead.