### PR TITLE
Add from_or_boxed constructor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        features: ["", "--features alloc"]
+        features: ["", "--no-default-features"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
     name: "Miri"
     strategy:
       matrix:
-        features: ["", "--features alloc"]
+        features: ["", "--no-default-features"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        features: ["", "--features alloc"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -21,12 +24,15 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-features --all-targets -- -D warnings
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose ${{ matrix.features }}
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose ${{ matrix.features }}
 
   miri:
     name: "Miri"
+    strategy:
+      matrix:
+        features: ["", "--features alloc"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,4 +42,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ categories = ["asynchronous", "no-std", "rust-patterns"]
 futures = { version = "0.3", features = ["executor"] }
 
 [features]
+default = ["alloc"]
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "stackfuture"
 description = "StackFuture is a wrapper around futures that stores the wrapped future in space provided by the caller."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Microsoft"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ categories = ["asynchronous", "no-std", "rust-patterns"]
 
 [dev-dependencies]
 futures = { version = "0.3", features = ["executor"] }
+
+[features]
+alloc = []


### PR DESCRIPTION
This gives us a way to support any size future with a small value optimization. The `from_or_boxed` constructor attempts to store the wrapped future in `StackFuture`'s reserved space, but if it cannot then it store the future in a box and wrap the box instead.

Note that doing this requires adding an "alloc" feature so this crate can continue to be used in pure no_std environments.

This also changes the panic behavior of `try_from` to not panic on alignment errors. To make it easier to determine why something went wrong, we make the `has_*_for*` functions public. We also adjust the panic messages in `StackFuture::from` to make it clear which conditions failed.

Finally, we introduce a testing matrix for GitHub actions to make sure we run tests both with and without allocation.