### PR TITLE
Make StackFuture::from fail statically if the future doesn't fit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "stackfuture"
 description = "StackFuture is a wrapper around futures that stores the wrapped future in space provided by the caller."
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Microsoft"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 // std is needed to run tests, but otherwise we don't need it.
 #![cfg_attr(not(test), no_std)]
 #![warn(missing_docs)]
-#![allow(clippy::let_unit_value)]
 
 use core::future::Future;
 use core::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
     ///     async {}.await;
     ///     println!("{}", x.len());
     /// });
+    /// # #[cfg(miri)] break rust; // FIXME: miri doesn't detect this breakage for some reason...
     /// ```
     ///
     /// The example below illustrates a compiler error for a future whose alignment is too large.
@@ -127,6 +128,7 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
     ///     async {}.await;
     ///     println!("{x:?}");
     /// });
+    /// # #[cfg(miri)] break rust; // FIXME: miri doesn't detect this breakage for some reason...
     /// ```
     pub fn from<F>(future: F) -> Self
     where
@@ -142,6 +144,7 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
         // both impls end up being applicable to do `From<StackFuture> for StackFuture`.
 
         // Statically assert that `F` meets all the size and alignment requirements
+        #[allow(clippy::let_unit_value)]
         let _ = AssertFits::<F, STACK_SIZE>::ASSERT;
 
         // Since we have the static assert above, we know this will not fail. This means we could

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -81,6 +81,21 @@ fn destructor_runs() {
 }
 
 #[test]
+fn test_size_failure() {
+    async fn fill_buf(buf: &mut [u8]) {
+        buf[0] = 42;
+    }
+
+    let f = async {
+        let mut buf = [0u8; 256];
+        fill_buf(&mut buf).await;
+        buf[0]
+    };
+
+    assert!(StackFuture::<_, 4>::try_from(f).is_err());
+}
+
+#[test]
 fn test_alignment() {
     // A test to make sure we store the wrapped future with the correct alignment
 
@@ -99,7 +114,6 @@ fn test_alignment() {
 }
 
 #[test]
-#[should_panic]
 fn test_alignment_failure() {
     // A test to make sure we store the wrapped future with the correct alignment
 
@@ -113,7 +127,7 @@ fn test_alignment_failure() {
             Poll::Pending
         }
     }
-    StackFuture::<'_, _, 1016>::from(BigAlignment(42));
+    assert!(StackFuture::<'_, _, 1016>::try_from(BigAlignment(42)).is_err());
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Thanks to @jstarks for the suggestion of how to do this!

This also bumps the version in `Cargo.toml` to `0.3.0` since it's a breaking change now that `StackFuture::from` will fail to compile in cases where it would have panicked at runtime.