### PR TITLE
Add `IntoStackFutureError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,8 +403,11 @@ impl<F> Display for IntoStackFutureError<F> {
 
 impl<F> Debug for IntoStackFutureError<F> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Forward to the Display implementation
-        write!(f, "{self}")
+        f.debug_struct("IntoStackFutureError")
+            .field("maximum_size", &self.maximum_size)
+            .field("maximum_alignment", &self.maximum_alignment)
+            .field("future", &core::any::type_name::<F>())
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<'a, T, const STACK_SIZE: usize> StackFuture<'a, T, { STACK_SIZE }> {
     where
         F: Future<Output = T> + Send + 'a, // the bounds here should match those in the _phantom field
     {
-        Self::try_from(future).unwrap_or_else(|future| Self::from(Box::pin(future.into_future())))
+        Self::try_from(future).unwrap_or_else(|err| Self::from(Box::pin(err.into_future())))
     }
 
     /// A wrapper around the inner future's poll function, which we store in the poll_fn field

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,6 @@ use futures::Future;
 use futures::SinkExt;
 use futures::Stream;
 use futures::StreamExt;
-use std::future::IntoFuture;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Wake;
@@ -197,7 +196,7 @@ fn try_from() {
     match StackFuture::<_, 10>::try_from(big_future) {
         Ok(_) => panic!("try_from should not have succeeded"),
         Err(big_future) => {
-            assert!(StackFuture::<_, 1500>::try_from(big_future.into_future()).is_ok())
+            assert!(StackFuture::<_, 1500>::try_from(big_future.into_inner()).is_ok())
         }
     };
 }


### PR DESCRIPTION
This is perhaps an over-designed error type, but it provides enough information to figure out why the conversion failed, which can help the programmer fix it.

This PR also includes #20, so review that first and I'll merge that one and rebase this one before merging it.

It would be nice to add a `impl std::error::Error for IntoStackFutureError`, but for now we are a `no_std` crate and I wasn't sure adding a `no_std` feature would be worth it just for that impl. I think the plan is for the `Error` trait to become part of core someday, so we could just wait until then.