### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/stackfuture/security/code-scanning/2](https://github.com/microsoft/stackfuture/security/code-scanning/2)

To address this issue, we should add the minimal required `permissions` key to the workflow. Since neither the `build` nor the `miri` job requires anything beyond reading repository contents (for checking out code to build/test), we set `contents: read` as the global permissions. The most efficient and maintainable fix is to add the `permissions` property at the root of the workflow file (just after the `name:` and before the jobs section), so it applies to all jobs. No changes to imports or job steps are needed.

Specifically, edit `.github/workflows/rust.yml`:
- Insert a top-level `permissions:` block directly after the `name: Rust` line, prior to the `on:` block.
- Set `contents: read` within this block.

No other code, imports, methods, or definitions are required for this correction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
