### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/microsoft/stackfuture/compare/v0.3.0...v0.3.1) - 2025-11-18
+
+### Other
+
+- Change 'F' to 'Future' in panic messages
+- Print detailed panic messages
+- Potential fix for code scanning alert no. 2: Workflow does not contain permissions
+- Fix another dead_code issue
+- cargo fmt
+- General updates, cleanups, and fixes
+- Add auto-updates from dependabot
+- Add missing copyright header and fix SUPPORT.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "stackfuture"
 description = "StackFuture is a wrapper around futures that stores the wrapped future in space provided by the caller."
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 authors = ["Microsoft"]


### PR DESCRIPTION



## 🤖 New release

* `stackfuture`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/microsoft/stackfuture/compare/v0.3.0...v0.3.1) - 2025-11-18

### Other

- Change 'F' to 'Future' in panic messages
- Print detailed panic messages
- Potential fix for code scanning alert no. 2: Workflow does not contain permissions
- Fix another dead_code issue
- cargo fmt
- General updates, cleanups, and fixes
- Add auto-updates from dependabot
- Add missing copyright header and fix SUPPORT.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).